### PR TITLE
Support Blish HUD v0.10.0+

### DIFF
--- a/Controls/DrawRing.cs
+++ b/Controls/DrawRing.cs
@@ -1,11 +1,12 @@
 ﻿using Blish_HUD;
+using Blish_HUD.Entities;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 
 namespace DistanceRings.Control
 {
-    public class DrawRing : Blish_HUD.Entities.Primitives.Cuboid
+    public class DrawRing : IEntity
     {
         public Texture2D RingTexture;
         public float RingOpacity;
@@ -13,9 +14,21 @@ namespace DistanceRings.Control
         public Color RingColor;
         private VertexPositionColorTexture[] vertex;
 
+        private VertexBuffer _geometryBuffer;
+
+        public Vector3 Size { get; set; }
+
+        public float VerticalOffset { get; set; }
+
+        public float DrawOrder => 0;
+
+        private static BasicEffect _renderEffect;
+
         public DrawRing()
         {
-            this.Size = new Vector3(0, 0, 0);
+            _renderEffect = _renderEffect ?? new BasicEffect(GameService.Graphics.GraphicsDevice);
+
+            this.Size = Vector3.Zero;
             this.RingOpacity = 1f;
             this.RingColor = Color.White;
             this.RingVisible = false;
@@ -45,30 +58,26 @@ namespace DistanceRings.Control
             _geometryBuffer.SetData(vertex);
         }
 
-        public override void HandleRebuild(GraphicsDevice graphicsDevice)
-        {
-        }
 
-        public override void Draw(GraphicsDevice graphicsDevice)
+
+        public void Render(GraphicsDevice graphicsDevice, IWorld world, ICamera camera)
         {
-            if (this.RingVisible)
+            if (this.RingVisible && _geometryBuffer != null)
             {
-                if (_geometryBuffer == null) return;
-
                 float x = GameService.Gw2Mumble.PlayerCharacter.Position.X;
                 float y = GameService.Gw2Mumble.PlayerCharacter.Position.Y;
                 float z = GameService.Gw2Mumble.PlayerCharacter.Position.Z + VerticalOffset;
 
                 float facing = (float)(Math.Atan2(GameService.Gw2Mumble.PlayerCamera.Forward.X, GameService.Gw2Mumble.PlayerCamera.Forward.Y) * 180 / Math.PI);
-                Matrix world = Matrix.CreateTranslation(x, y, z);
-                world.M11 = (float)(Math.Cos(MathHelper.ToRadians(facing)));
-                world.M12 = (float)(-Math.Sin(MathHelper.ToRadians(facing)));
-                world.M21 = (float)(Math.Sin(MathHelper.ToRadians(facing)));
-                world.M22 = (float)(Math.Cos(MathHelper.ToRadians(facing)));
-
+                Matrix worldMatrix = Matrix.CreateTranslation(x, y, z);
+                worldMatrix.M11 = (float)(Math.Cos(MathHelper.ToRadians(facing)));
+                worldMatrix.M12 = (float)(-Math.Sin(MathHelper.ToRadians(facing)));
+                worldMatrix.M21 = (float)(Math.Sin(MathHelper.ToRadians(facing)));
+                worldMatrix.M22 = (float)(Math.Cos(MathHelper.ToRadians(facing)));
+                
                 _renderEffect.View = GameService.Gw2Mumble.PlayerCamera.View;
                 _renderEffect.Projection = GameService.Gw2Mumble.PlayerCamera.Projection;
-                _renderEffect.World = world;
+                _renderEffect.World = worldMatrix;
                 _renderEffect.Texture = RingTexture;
                 _renderEffect.Alpha = RingOpacity;
 
@@ -83,5 +92,7 @@ namespace DistanceRings.Control
                     2);
             }
         }
+
+        public void Update(GameTime gameTime) { /* NOOP */ }
     }
 }

--- a/DistanceRings.csproj
+++ b/DistanceRings.csproj
@@ -73,15 +73,19 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Blish HUD, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\BlishHUD.0.8.0-ci.89\lib\net472\Blish HUD.exe</HintPath>
+    <Reference Include="Blish HUD, Version=0.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\BlishHUD.0.10.0-ci.91\lib\net472\Blish HUD.exe</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="CSCore, Version=1.2.1.2, Culture=neutral, PublicKeyToken=5a08f2b6f4415dea, processorArchitecture=MSIL">
       <HintPath>packages\CSCore.1.2.1.2\lib\net35-client\CSCore.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Gw2Sharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Gw2Sharp.1.0.0\lib\netstandard2.0\Gw2Sharp.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -224,12 +228,12 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\MonoGame.Framework.WindowsDX.3.7.1.189\build\MonoGame.Framework.WindowsDX.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\MonoGame.Framework.WindowsDX.3.7.1.189\build\MonoGame.Framework.WindowsDX.targets'))" />
-    <Error Condition="!Exists('packages\BlishHUD.0.8.0-ci.89\build\BlishHUD.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\BlishHUD.0.8.0-ci.89\build\BlishHUD.targets'))" />
+    <Error Condition="!Exists('packages\BlishHUD.0.10.0-ci.91\build\BlishHUD.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\BlishHUD.0.10.0-ci.91\build\BlishHUD.targets'))" />
   </Target>
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties manifest_1json__JsonSchema="" />
     </VisualStudio>
   </ProjectExtensions>
-  <Import Project="packages\BlishHUD.0.8.0-ci.89\build\BlishHUD.targets" Condition="Exists('packages\BlishHUD.0.8.0-ci.89\build\BlishHUD.targets')" />
+  <Import Project="packages\BlishHUD.0.10.0-ci.91\build\BlishHUD.targets" Condition="Exists('packages\BlishHUD.0.10.0-ci.91\build\BlishHUD.targets')" />
 </Project>

--- a/DistanceRings.csproj
+++ b/DistanceRings.csproj
@@ -74,8 +74,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Blish HUD, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\BlishHUD.0.8.0-ci.72\lib\net472\Blish HUD.exe</HintPath>
-      <Private>False</Private>
+      <HintPath>packages\BlishHUD.0.8.0-ci.89\lib\net472\Blish HUD.exe</HintPath>
     </Reference>
     <Reference Include="CSCore, Version=1.2.1.2, Culture=neutral, PublicKeyToken=5a08f2b6f4415dea, processorArchitecture=MSIL">
       <HintPath>packages\CSCore.1.2.1.2\lib\net35-client\CSCore.dll</HintPath>
@@ -225,12 +224,12 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\MonoGame.Framework.WindowsDX.3.7.1.189\build\MonoGame.Framework.WindowsDX.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\MonoGame.Framework.WindowsDX.3.7.1.189\build\MonoGame.Framework.WindowsDX.targets'))" />
-    <Error Condition="!Exists('packages\BlishHUD.0.8.0-ci.72\build\BlishHUD.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\BlishHUD.0.8.0-ci.72\build\BlishHUD.targets'))" />
+    <Error Condition="!Exists('packages\BlishHUD.0.8.0-ci.89\build\BlishHUD.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\BlishHUD.0.8.0-ci.89\build\BlishHUD.targets'))" />
   </Target>
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties manifest_1json__JsonSchema="" />
     </VisualStudio>
   </ProjectExtensions>
-  <Import Project="packages\BlishHUD.0.8.0-ci.72\build\BlishHUD.targets" Condition="Exists('packages\BlishHUD.0.8.0-ci.72\build\BlishHUD.targets')" />
+  <Import Project="packages\BlishHUD.0.8.0-ci.89\build\BlishHUD.targets" Condition="Exists('packages\BlishHUD.0.8.0-ci.89\build\BlishHUD.targets')" />
 </Project>

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
     "name": "Distance Rings",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "namespace": "DistanceRings",
     "package": "DistanceRings.dll",
     "manifest_version": 1,
 
     "description": "Display Distance Rings to mark skill ranges and player location",
     "dependencies": {
-        "bh.blishhud": ">=0.8.0"
+        "bh.blishhud": ">=0.10.0"
     },
     "url": "https://github.com/manlaan/Blishhud-DistanceRings",
     "contributors": [

--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncClipboardService" version="1.7.1" targetFramework="net472" />
-  <package id="BlishHUD" version="0.8.0-ci.89" targetFramework="net472" />
+  <package id="BlishHUD" version="0.10.0-ci.91" targetFramework="net472" />
   <package id="CSCore" version="1.2.1.2" targetFramework="net472" />
   <package id="Gw2Sharp" version="1.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />

--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncClipboardService" version="1.7.1" targetFramework="net472" />
-  <package id="BlishHUD" version="0.8.0-ci.72" targetFramework="net472" />
+  <package id="BlishHUD" version="0.8.0-ci.89" targetFramework="net472" />
   <package id="CSCore" version="1.2.1.2" targetFramework="net472" />
   <package id="Gw2Sharp" version="1.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />


### PR DESCRIPTION
Blish HUD v0.10.0 and beyond removes much of the old Entity classes which were overly specific.  The changes here re-introduce support by now implementing IEntity.

Not that much had to change since the DrawRing class was already handling most of its own VertexBuffer already.